### PR TITLE
Add simple C# Web API with JWT authentication

### DIFF
--- a/UserAuthApi/Controllers/AuthController.cs
+++ b/UserAuthApi/Controllers/AuthController.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc;
+using UserAuthApi.Models;
+using UserAuthApi.Services;
+
+namespace UserAuthApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly UserService _users;
+    private readonly TokenService _tokens;
+
+    public AuthController(UserService users, TokenService tokens)
+    {
+        _users = users;
+        _tokens = tokens;
+    }
+
+    [HttpPost("register")]
+    public IActionResult Register(UserDto request)
+    {
+        var created = _users.Register(request.Username, request.Password);
+        if (!created)
+        {
+            return BadRequest("User already exists");
+        }
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public IActionResult Login(UserDto request)
+    {
+        var user = _users.Authenticate(request.Username, request.Password);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+        var token = _tokens.CreateToken(user);
+        return Ok(new { token });
+    }
+}
+
+public record UserDto(string Username, string Password);

--- a/UserAuthApi/Models/User.cs
+++ b/UserAuthApi/Models/User.cs
@@ -1,0 +1,8 @@
+namespace UserAuthApi.Models;
+
+public class User
+{
+    public string Username { get; set; } = string.Empty;
+    public byte[] PasswordHash { get; set; } = Array.Empty<byte>();
+    public byte[] PasswordSalt { get; set; } = Array.Empty<byte>();
+}

--- a/UserAuthApi/Program.cs
+++ b/UserAuthApi/Program.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+using UserAuthApi.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddSingleton<UserService>();
+builder.Services.AddSingleton<TokenService>();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/UserAuthApi/Services/TokenService.cs
+++ b/UserAuthApi/Services/TokenService.cs
@@ -1,0 +1,37 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using UserAuthApi.Models;
+
+namespace UserAuthApi.Services;
+
+public class TokenService
+{
+    private readonly IConfiguration _config;
+
+    public TokenService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public string CreateToken(User user)
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, user.Username)
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/UserAuthApi/Services/UserService.cs
+++ b/UserAuthApi/Services/UserService.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+using System.Text;
+using UserAuthApi.Models;
+
+namespace UserAuthApi.Services;
+
+public class UserService
+{
+    private readonly List<User> _users = new();
+
+    public bool Register(string username, string password)
+    {
+        if (_users.Any(u => u.Username == username))
+        {
+            return false;
+        }
+
+        CreatePasswordHash(password, out var hash, out var salt);
+        _users.Add(new User { Username = username, PasswordHash = hash, PasswordSalt = salt });
+        return true;
+    }
+
+    public User? Authenticate(string username, string password)
+    {
+        var user = _users.SingleOrDefault(u => u.Username == username);
+        if (user is null)
+        {
+            return null;
+        }
+
+        return VerifyPasswordHash(password, user.PasswordHash, user.PasswordSalt) ? user : null;
+    }
+
+    private static void CreatePasswordHash(string password, out byte[] hash, out byte[] salt)
+    {
+        using var hmac = new HMACSHA512();
+        salt = hmac.Key;
+        hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+    }
+
+    private static bool VerifyPasswordHash(string password, byte[] hash, byte[] salt)
+    {
+        using var hmac = new HMACSHA512(salt);
+        var computed = hmac.ComputeHash(Encoding.UTF8.GetBytes(password));
+        return computed.SequenceEqual(hash);
+    }
+}

--- a/UserAuthApi/UserAuthApi.csproj
+++ b/UserAuthApi/UserAuthApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/UserAuthApi/appsettings.json
+++ b/UserAuthApi/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Jwt": {
+    "Key": "supersecretkey1234567890",
+    "Issuer": "UserAuthApi",
+    "Audience": "UserAuthApi"
+  }
+}


### PR DESCRIPTION
## Summary
- add `UserAuthApi` project with endpoints for user registration and login
- implement JWT token generation and in-memory user store

## Testing
- `pytest tests/test_config.py -q`
- `pre-commit run --files UserAuthApi/Program.cs UserAuthApi/Models/User.cs UserAuthApi/Services/UserService.cs UserAuthApi/Services/TokenService.cs UserAuthApi/Controllers/AuthController.cs UserAuthApi/appsettings.json UserAuthApi/UserAuthApi.csproj` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10')*


------
https://chatgpt.com/codex/tasks/task_e_68962386837c832994e0c6a3118facda